### PR TITLE
Start xvfb and run chrome without headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ FROM public.ecr.aws/lambda/python@sha256:9cc6f47de700608ee0420246dac500edd34d059
 RUN yum install atk cups-libs gtk3 libXcomposite alsa-lib \
     libXcursor libXdamage libXext libXi libXrandr libXScrnSaver \
     libXtst pango at-spi2-atk libXt xorg-x11-server-Xvfb \
-    xorg-x11-xauth dbus-glib dbus-glib-devel -y
+    xorg-x11-xauth dbus-glib dbus-glib-devel procps xdpyinfo -y
 RUN pip install selenium
 COPY --from=build /opt/chrome-linux /opt/chrome
 COPY --from=build /opt/chromedriver /opt/
 COPY main.py ./
 CMD [ "main.handler" ]
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+export DISPLAY=:99
+/usr/bin/Xvfb "$DISPLAY" -screen 0 1280x800x24 &
+
+# Wait for Xvfb
+MAX_ATTEMPTS=120 # About 60 seconds
+COUNT=0
+echo -n "Waiting for Xvfb to be ready..."
+while ! xdpyinfo -display "$DISPLAY" >/dev/null 2>&1; do
+  echo -n "."
+  sleep 0.50s
+  COUNT=$(( COUNT + 1 ))
+  if [ "${COUNT}" -ge "${MAX_ATTEMPTS}" ]; then
+    echo "  Gave up waiting for X server on $DISPLAY"
+    exit 1
+  fi
+done
+echo "  Done - Xvfb is ready!"
+
+/lambda-entrypoint.sh "$1"

--- a/main.py
+++ b/main.py
@@ -6,14 +6,11 @@ from selenium.webdriver.common.by import By
 def handler(event=None, context=None):
     options = webdriver.ChromeOptions()
     options.binary_location = '/opt/chrome/chrome'
-    options.add_argument('--headless')
     options.add_argument('--no-sandbox')
     options.add_argument("--disable-gpu")
     options.add_argument("--window-size=1280x1696")
     options.add_argument("--single-process")
     options.add_argument("--disable-dev-shm-usage")
-    options.add_argument("--disable-dev-tools")
-    options.add_argument("--no-zygote")
     options.add_argument(f"--user-data-dir={mkdtemp()}")
     options.add_argument(f"--data-path={mkdtemp()}")
     options.add_argument(f"--disk-cache-dir={mkdtemp()}")


### PR DESCRIPTION
Found your repo really helpful in setting up my selenium pytest tests to run in parallel, thanks! Just thought you might like to know that you can run chrome without the "--headless" if you start Xvfb first. You can then do things like record videos with ffmpeg.