### PR TITLE
fix: use temporarily serverless@^3 instead of v4 which require login

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -31,7 +31,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
       - name: Install serverless
-        run: npm install -g serverless
+        run: npm install -g serverless@^3
       - name: Note docker image digest
         id: docker-image-digest
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
       - name: Install Serverless Framework
-        run: npm install -g serverless
+        run: npm install -g serverless@^3
       - name: Wait for CloudFormation stack to be updated
         run: aws cloudformation wait stack-update-complete --stack-name="docker-selenium-lambda-prod" || true
       - name: Deploy

--- a/.github/workflows/demo-test.yml
+++ b/.github/workflows/demo-test.yml
@@ -27,7 +27,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
       - name: Demo README's instructions
         run: |
-          npm install -g serverless
+          npm install -g serverless@^3
           sls create --template-url "https://github.com/umihico/docker-selenium-lambda/tree/main" --path docker-selenium-lambda && cd $_
           sls deploy
           sls invoke --function demo |& tee /tmp/scraping-result.txt

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This image goes with these versions. [These are automatically updated and tested
 ## Running the demo
 
 ```bash
-$ npm install -g serverless # skip this line if you have already installed Serverless Framework
+$ npm install -g serverless@^3 # skip this line if you have already installed Serverless Framework
 $ export AWS_REGION=ap-northeast-1 # You can specify region or skip this line. us-east-1 will be used by default.
 $ sls create --template-url "https://github.com/umihico/docker-selenium-lambda/tree/main" --path docker-selenium-lambda && cd $_
 $ sls deploy


### PR DESCRIPTION
https://www.serverless.com/framework/docs-guides-upgrading-v4

<img width="1073" alt="スクリーンショット 2024-05-24 10 46 27" src="https://github.com/umihico/docker-selenium-lambda/assets/39179585/fefa965c-142f-476f-9a72-48236fbb8364">
<img width="1312" alt="スクリーンショット 2024-05-24 10 46 51" src="https://github.com/umihico/docker-selenium-lambda/assets/39179585/132bf974-b3ba-4b38-a617-849faac1e3b4">

Thank you for reporting, Loïc