### PR TITLE
Add extra flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM public.ecr.aws/lambda/python@sha256:7c0b6f5a3937f34b2ff0553898dce1a8711c3da6f789f6c4b495e54618a930e2 as build
-RUN dnf install -y unzip && \
+FROM public.ecr.aws/lambda/python@sha256:7c0b6f5a3937f34b2ff0553898dce1a8711c3da6f789f6c4b495e54618a930e2 AS build
+RUN dnf install -y --nodocs unzip && \
     curl -Lo "/tmp/chromedriver-linux64.zip" "https://storage.googleapis.com/chrome-for-testing-public/139.0.7258.66/linux64/chromedriver-linux64.zip" && \
     curl -Lo "/tmp/chrome-linux64.zip" "https://storage.googleapis.com/chrome-for-testing-public/139.0.7258.66/linux64/chrome-linux64.zip" && \
     unzip /tmp/chromedriver-linux64.zip -d /opt/ && \
     unzip /tmp/chrome-linux64.zip -d /opt/
 
 FROM public.ecr.aws/lambda/python@sha256:7c0b6f5a3937f34b2ff0553898dce1a8711c3da6f789f6c4b495e54618a930e2
-RUN dnf install -y atk cups-libs gtk3 libXcomposite alsa-lib \
+RUN dnf install -y --nodocs --setopt=install_weak_deps=0 \
+    atk cups-libs gtk3 libXcomposite alsa-lib \
     libXcursor libXdamage libXext libXi libXrandr libXScrnSaver \
     libXtst pango at-spi2-atk libXt xorg-x11-server-Xvfb \
-    xorg-x11-xauth dbus-glib dbus-glib-devel nss mesa-libgbm
-RUN pip install selenium==4.34.2
+    xorg-x11-xauth dbus-glib dbus-glib-devel nss mesa-libgbm && \
+    dnf clean all && rm -rf /var/cache/dnf/* && \
+    pip install --no-cache-dir -U selenium==4.34.2
 COPY --from=build /opt/chrome-linux64 /opt/chrome
 COPY --from=build /opt/chromedriver-linux64 /opt/
 COPY main.py ./


### PR DESCRIPTION
These are some changes that reduce the image size and make the build faster

dnf:
--nodocs doesn't install documentation files, can be be checked with e.g rpm -qd unzip

Using install_weak_deps=0 installs about 110 less packages, can be checked with dnf install

clean all will remove package install cache, I also added in a rm -rf for the "best practices"

pip:
--no-cache-dir kinda self-explanatory

-U will upgrade the package if there's a new release

Overall the difference in the image size is 2.58GB without, versus 2.06GB with the new flags

I also corrected this `=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`

Of course I ran a basic test to make sure that it still works

```
curl 'http://localhost:9000/2015-03-31/functions/function/invocations' -d '{}'
"Example Domain\nThis domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\nMore information..."
```